### PR TITLE
fix: use NODE_AUTH_TOKEN in .yarnrc.yml for setup-node@v7 compatibility

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SKIP_YARN_COREPACK_CHECK: true
+      NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
     permissions:
       contents: read
       id-token: write
@@ -28,8 +29,6 @@ jobs:
           path: node_modules
           key: ${{ runner.os }}-modules-${{ hashFiles('yarn.lock') }}
       - name: Install dependencies
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
         if: steps.cache-node_modules.outputs.cache-hit != 'true'
         run: yarn install --immutable
       - name: Test

--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -15,7 +15,7 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
           registry-url: https://npm.pkg.github.com
@@ -29,7 +29,7 @@ jobs:
           key: ${{ runner.os }}-modules-${{ hashFiles('yarn.lock') }}
       - name: Install dependencies
         env:
-          NPM_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
         if: steps.cache-node_modules.outputs.cache-hit != 'true'
         run: yarn install --immutable
       - name: Test

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -12,7 +12,7 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
           registry-url: https://npm.pkg.github.com
@@ -26,7 +26,7 @@ jobs:
           key: ${{ runner.os }}-modules-${{ hashFiles('yarn.lock') }}
       - name: Install dependencies
         env:
-          NPM_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
         if: steps.cache-node_modules.outputs.cache-hit != 'true'
         run: yarn install --immutable
       - name: Test

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -7,6 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SKIP_YARN_COREPACK_CHECK: true
+      NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
     permissions:
       contents: read
       id-token: write
@@ -25,8 +26,6 @@ jobs:
           path: node_modules
           key: ${{ runner.os }}-modules-${{ hashFiles('yarn.lock') }}
       - name: Install dependencies
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
         if: steps.cache-node_modules.outputs.cache-hit != 'true'
         run: yarn install --immutable
       - name: Test

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -10,5 +10,5 @@ npmMinimalAgeGate: 2800
 npmScopes:
   navikt:
     npmAlwaysAuth: true
-    npmAuthToken: "${NPM_AUTH_TOKEN:-}"
+    npmAuthToken: "${NODE_AUTH_TOKEN:-}"
     npmRegistryServer: "https://npm.pkg.github.com"


### PR DESCRIPTION
## Problem
`actions/setup-node@v7` removed the dummy `NODE_AUTH_TOKEN` export and no longer recognizes `NPM_AUTH_TOKEN`. Yarn berry reads auth directly from `.yarnrc.yml`, so the token reference must match the env var that `setup-node` sets.

## Change
Rename `NPM_AUTH_TOKEN` → `NODE_AUTH_TOKEN` in `.yarnrc.yml`.

Same fix applied in navikt/mine-aap.