### PR TITLE
chore: add systemkatalog.nav.no/system label to nais manifest

### DIFF
--- a/.nais/dev.yaml
+++ b/.nais/dev.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: aap
     sub: brev-sanity-proxy
-    systemkatalog.nav.no/system: TE-496
+    systemkatalog.nav.no/system: SK-268
 spec:
   image: {{image}}
   replicas:

--- a/.nais/dev.yaml
+++ b/.nais/dev.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     team: aap
     sub: brev-sanity-proxy
+    systemkatalog.nav.no/system: TE-496
 spec:
   image: {{image}}
   replicas:

--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: aap
     sub: brev-sanity-proxy
-    systemkatalog.nav.no/system: TE-496
+    systemkatalog.nav.no/system: SK-268
 spec:
   image: {{image}}
   replicas:

--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     team: aap
     sub: brev-sanity-proxy
+    systemkatalog.nav.no/system: TE-496
 spec:
   image: {{image}}
   replicas:


### PR DESCRIPTION
Adds the `systemkatalog.nav.no/system: TE-496` label to the nais Application manifest so this app is registered in systemkatalog.nav.no.